### PR TITLE
Support different naming for api key header and fields

### DIFF
--- a/lib/passport-localapikey/strategy.js
+++ b/lib/passport-localapikey/strategy.js
@@ -21,14 +21,15 @@ var passport = require('passport')
  * credentials are found.
  *
  * Options:
- *   - `apiKeyField`  field name where the username is found, defaults to _apiKey_
+ *   - `apiKeyField`  field name where the apikey is found, defaults to _apiKey_
+ *   - `apiKeyHeader`  header name where the apikey is found, defaults to _apiKey_
  *   - `passReqToCallback`  when `true`, `req` is the first argument to the verify callback (default: `false`)
  *
  * Examples:
  *
  *     passport.use(new LocalAPIKeyStrategy(
- *       function(username, password, done) {
- *         User.findOne({ username: username, password: password }, function (err, user) {
+ *       function(apikey, done) {
+ *         User.findOne({ apikey: apikey }, function (err, user) {
  *           done(err, user);
  *         });
  *       }
@@ -46,6 +47,7 @@ function Strategy(options, verify) {
   if (!verify) throw new Error('local authentication strategy requires a verify function');
 
   this._apiKeyField = options.apiKeyField || 'apikey';
+  this._apiKeyHeader = options.apiKeyHeader || 'apikey';
 
   passport.Strategy.call(this);
   this.name = 'localapikey';
@@ -68,7 +70,7 @@ Strategy.prototype.authenticate = function(req, options) {
   options = options || {};
   var apikey = lookup(req.body, this._apiKeyField)
     || lookup(req.query, this._apiKeyField)
-    || lookup(req.headers, this._apiKeyField);
+    || lookup(req.headers, this._apiKeyHeader);
 
   if (!apikey) {
     return this.fail(new BadRequestError(options.badRequestMessage || 'Missing API Key'));


### PR DESCRIPTION
This commmit allows to set a different name for header or query/body parameters
