### PR TITLE
Add optionalApiKey option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ credentials and calls `done` providing a user.
       }
     ));
 
+##### To make *apikey* optional (in case you are using more then one strategy)
+
+This will tell Local API Key strategy to skip authentication if *apikey* is not found
+in headers, query string or request body. If you have secondary authentication via,
+for example, username and password using sessions, set *optionalApiKey*  option to
+*true* to keep user logged in when *apikey* is not passed.
+
+    passport.use(new LocalAPIKeyStrategy({
+        optionalApiKey: true
+      }, function(apikey, done) {
+        [...]
+      }
+    ));
+
 #### Authenticate Requests
 
 Use `passport.authenticate()`, specifying the `'localapikey'` strategy, to

--- a/lib/passport-localapikey/strategy.js
+++ b/lib/passport-localapikey/strategy.js
@@ -48,6 +48,7 @@ function Strategy(options, verify) {
 
   this._apiKeyField = options.apiKeyField || 'apikey';
   this._apiKeyHeader = options.apiKeyHeader || 'apikey';
+  this._optionalApiKey = options.optionalApiKey || false;
 
   passport.Strategy.call(this);
   this.name = 'localapikey';
@@ -73,7 +74,12 @@ Strategy.prototype.authenticate = function(req, options) {
     || lookup(req.headers, this._apiKeyHeader);
 
   if (!apikey) {
-    return this.fail(new BadRequestError(options.badRequestMessage || 'Missing API Key'));
+    if (this._optionalApiKey) {
+      this.pass();
+    }
+    else {
+      return this.fail(new BadRequestError(options.badRequestMessage || 'Missing API Key'));
+    }
   }
 
   var self = this;


### PR DESCRIPTION
I have use case where I use LocalAPIKey strategy to authenticate each REST request with apikey passed in query string with each request. And at the same time I am using password authentication with sessions to allow browser app have access to the same API endpoints. To allow that I had to allow Local API Key strategy not fail when 'apikey' is not found. This is optional and should not break existing applications.
